### PR TITLE
[NEW] Support extra params in UserProfile

### DIFF
--- a/src/documents/android/profile/Profile_MainClasses.html.md
+++ b/src/documents/android/profile/Profile_MainClasses.html.md
@@ -43,7 +43,10 @@ This class holds information about a user for a specific `IProvider`.
 - `Username`
 - `FirstName`
 - `LastName`
-- `Extra` (a dictionary contains additional info provided by social provider, such as access token, granted permissions, etc.)
+- `Extra` - a dictionary contains additional info provided by social provider:
+  - `Facebook` - access_token(String), permissions(JSONArray of Strings);
+  - `Twitter` - access_token(String);
+  - `Google+` - access_token(String).
 
 ## SoomlaProfile <a href="https://github.com/soomla/android-profile/blob/master/SoomlaAndroidProfile/src/com/soomla/profile/SoomlaProfile.java" target="_blank"><img class="link-icon" src="/img/tutorial_img/linkImg.png"></a>
 

--- a/src/documents/android/profile/Profile_MainClasses.html.md
+++ b/src/documents/android/profile/Profile_MainClasses.html.md
@@ -43,6 +43,7 @@ This class holds information about a user for a specific `IProvider`.
 - `Username`
 - `FirstName`
 - `LastName`
+- `Extra` (a dictionary contains additional info provided by social provider, such as access token, granted permissions, etc.)
 
 ## SoomlaProfile <a href="https://github.com/soomla/android-profile/blob/master/SoomlaAndroidProfile/src/com/soomla/profile/SoomlaProfile.java" target="_blank"><img class="link-icon" src="/img/tutorial_img/linkImg.png"></a>
 

--- a/src/documents/android/profile/Profile_MainClasses.html.md
+++ b/src/documents/android/profile/Profile_MainClasses.html.md
@@ -43,7 +43,7 @@ This class holds information about a user for a specific `IProvider`.
 - `Username`
 - `FirstName`
 - `LastName`
-- `Extra` - a dictionary contains additional info provided by social provider:
+- `Extra` - a map contains additional info provided by social provider:
   - `Facebook` - access_token(String), permissions(JSONArray of Strings);
   - `Twitter` - access_token(String);
   - `Google+` - access_token(String).

--- a/src/documents/cocos2dx/cpp/profile/Profile_MainClasses.html.md
+++ b/src/documents/cocos2dx/cpp/profile/Profile_MainClasses.html.md
@@ -51,7 +51,10 @@ This class represents a profile of a user from a social network (provider).
 - `Gender`
 - `Language`
 - `Birthday`
-- `Extra` (a dictionary contains additional info provided by social provider, such as access token, granted permissions, etc.)
+- `Extra` - a cocos2dx::__Dictionary contains additional info provided by social provider:
+  - `Facebook` - access_token(cocos2dx::__String), permissions(cocos2dx::__Array of cocos2dx::__Strings), expiration_date(UNIX timestamp as cocos2dx::__Double) - not available for Android;
+  - `Twitter` - access_token(cocos2dx::__String);
+  - `Google+` - access_token(cocos2dx::__String), refresh_token(cocos2dx::__String) - not available for Android, expiration_date(UNIX timestamp as cocos2dx::__Double) - not available for Android.
 
 ## CCSoomlaProfile <a href="https://github.com/soomla/cocos2dx-profile/blob/master/Soomla/CCSoomlaProfile.h" target="_blank"><img class="link-icon" src="/img/tutorial_img/linkImg.png"></a>
 

--- a/src/documents/cocos2dx/cpp/profile/Profile_MainClasses.html.md
+++ b/src/documents/cocos2dx/cpp/profile/Profile_MainClasses.html.md
@@ -51,6 +51,7 @@ This class represents a profile of a user from a social network (provider).
 - `Gender`
 - `Language`
 - `Birthday`
+- `Extra` (a dictionary contains additional info provided by social provider, such as access token, granted permissions, etc.)
 
 ## CCSoomlaProfile <a href="https://github.com/soomla/cocos2dx-profile/blob/master/Soomla/CCSoomlaProfile.h" target="_blank"><img class="link-icon" src="/img/tutorial_img/linkImg.png"></a>
 

--- a/src/documents/cocos2dx/js/profile/Profile_MainClasses.html.md
+++ b/src/documents/cocos2dx/js/profile/Profile_MainClasses.html.md
@@ -51,6 +51,7 @@ This class represents a profile of a user from a social network (provider).
 - `Gender`
 - `Language`
 - `Birthday`
+- `Extra` (a dictionary contains additional info provided by social provider, such as access token, granted permissions, etc.)
 
 ## Soomla.SoomlaProfile
 

--- a/src/documents/cocos2dx/js/profile/Profile_MainClasses.html.md
+++ b/src/documents/cocos2dx/js/profile/Profile_MainClasses.html.md
@@ -51,7 +51,10 @@ This class represents a profile of a user from a social network (provider).
 - `Gender`
 - `Language`
 - `Birthday`
-- `Extra` (a dictionary contains additional info provided by social provider, such as access token, granted permissions, etc.)
+- `Extra` - a cocos2dx::__Dictionary contains additional info provided by social provider:
+  - `Facebook` - access_token(string), permissions(array of strings), expiration_date(UNIX timestamp as number) - not available for Android;
+  - `Twitter` - access_token(string);
+  - `Google+` - access_token(string), refresh_token(string) - not available for Android, expiration_date(UNIX timestamp as number) - not available for Android.
 
 ## Soomla.SoomlaProfile
 

--- a/src/documents/ios/profile/Profile_MainClasses.html.md
+++ b/src/documents/ios/profile/Profile_MainClasses.html.md
@@ -50,6 +50,7 @@ This class represents a profile of a user from a social network (provider).
 - `gender`
 - `language`
 - `birthday`
+- `extra` (a dictionary contains additional info provided by social provider, such as access token, granted permissions, etc.)
 
 ## SoomlaProfile <a href="https://github.com/soomla/ios-profile/blob/master/SoomlaiOSProfile/SoomlaProfile.h" target="_blank"><img class="link-icon" src="/img/tutorial_img/linkImg.png"></a>
 

--- a/src/documents/ios/profile/Profile_MainClasses.html.md
+++ b/src/documents/ios/profile/Profile_MainClasses.html.md
@@ -50,7 +50,10 @@ This class represents a profile of a user from a social network (provider).
 - `gender`
 - `language`
 - `birthday`
-- `extra` (a dictionary contains additional info provided by social provider, such as access token, granted permissions, etc.)
+- `extra` - a NSDictionary contains additional info provided by social provider:
+  - `Facebook` - access_token(NSString), permissions(NSArray of NSStrings), expiration_date(UNIX timestamp as NSNumber);
+  - `Twitter` - access_token(NSString);
+  - `Google+` - access_token(NSString), refresh_token(NSString), expiration_date(UNIX timestamp as NSNumber).
 
 ## SoomlaProfile <a href="https://github.com/soomla/ios-profile/blob/master/SoomlaiOSProfile/SoomlaProfile.h" target="_blank"><img class="link-icon" src="/img/tutorial_img/linkImg.png"></a>
 

--- a/src/documents/unity/profile/Profile_MainClasses.html.md
+++ b/src/documents/unity/profile/Profile_MainClasses.html.md
@@ -51,6 +51,7 @@ This class holds information about a user for a specific `Provider`.
 - `Gender`
 - `Language`
 - `Birthday`
+- `Extra` (a dictionary contains additional info provided by social provider, such as access token, granted permissions, etc.)
 
 ## SoomlaProfile <a href="https://github.com/soomla/unity3d-profile/blob/master/Soomla/Assets/Plugins/Soomla/Profile/SoomlaProfile.cs" target="_blank"><img class="link-icon" src="/img/tutorial_img/linkImg.png"></a>
 

--- a/src/documents/unity/profile/Profile_MainClasses.html.md
+++ b/src/documents/unity/profile/Profile_MainClasses.html.md
@@ -51,7 +51,10 @@ This class holds information about a user for a specific `Provider`.
 - `Gender`
 - `Language`
 - `Birthday`
-- `Extra` (a dictionary contains additional info provided by social provider, such as access token, granted permissions, etc.)
+- `Extra` - a Dictionary contains additional info provided by social provider:
+  - `Facebook` - access_token(String), permissions(JSONObject of Strings), expiration_date(UNIX timestamp as Double);
+  - `Twitter` - access_token(String);
+  - `Google+` - access_token(String), refresh_token(String) - not available for Android, expiration_date(UNIX timestamp as Double) - not available for Android.
 
 ## SoomlaProfile <a href="https://github.com/soomla/unity3d-profile/blob/master/Soomla/Assets/Plugins/Soomla/Profile/SoomlaProfile.cs" target="_blank"><img class="link-icon" src="/img/tutorial_img/linkImg.png"></a>
 


### PR DESCRIPTION
update docs with extra field description in user profile

Please, let me know where I should place 'extra' field description. I think we should leave description for extra field because it's not too easy to understand the direct purpose of this thing. But I feel that I choose wrong place for this (because fields enum doesn't have any description in the brackets).